### PR TITLE
truncate abstracts to show like button even if text is large, truncate authors, remove conflicting logos and add better fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paper Gram</title>
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
@@ -12,8 +15,6 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1 class="logo">Paper Gram</h1>
-    
     <button class="favorites-btn" id="favoritesToggle">
         Favorites
     </button>

--- a/script.js
+++ b/script.js
@@ -256,7 +256,8 @@ const container = document.getElementById('container');
                         </div>
                         <div class="paper-header">
                             <h2 class="title">${paper.title}</h2>
-                            <div class="authors">${paper.authors}</div>
+<div class="authors">${paper.authors.split(', ').length > 4 ? paper.authors.split(', ').slice(0, 4).join(', ') + ', et al.' : paper.authors}</div>
+
                         </div>
                         <div class="key-results">
                             ${keyResults.map(result => `
@@ -266,7 +267,7 @@ const container = document.getElementById('container');
                                 </div>
                             `).join('')}
                         </div>
-                        <p class="abstract">${paper.abstract}</p>
+                        <p class="abstract">${paper.abstract.length > 400 ? paper.abstract.substring(0, 400) + '...' : paper.abstract}</p>
                         <div class="metadata">
                             <span>${paper.published}</span>
                             <button class="like-button ${isLiked ? 'liked' : ''}">${isLiked ? '❤️' : '🤍'}</button>

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,21 @@
 :root {
-    --bg-color: #0a0b14;
+    --bg-color: #0c0e17;
     --card-bg: rgba(22, 24, 37, 0.9);
     --text-color: #e2e8f0;
     --accent-color: #64ffda;
     --secondary-text: #94a3b8;
 }
 
+/* hide scrollbar */
+::-webkit-scrollbar {
+    display: none;
+}
+
 * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'Space Grotesk', monospace;
 }
 
 body {
@@ -59,7 +64,8 @@ body {
 }
 
 .paper-card {
-    height: calc(100vh - 60px);
+    margin: auto;
+    min-height: calc(100vh - 100px);
     scroll-snap-align: start;
     display: flex;
     flex-direction: column;
@@ -70,16 +76,17 @@ body {
 }
 
 .paper-content {
-    background: var(--card-bg);
+    margin: auto;
+    margin-top: 2rem;
+      background: var(--card-bg);
     padding: 1.25rem;
     border-radius: 12px;
     border: 1px solid rgba(100, 255, 218, 0.1);
     width: calc(100% - 2rem);
-    max-width: 800px;
-    margin: 0 1rem;
+
+    max-width: 600px;
     backdrop-filter: blur(10px);
     opacity: 0;
-    transform: translateY(20px);
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
@@ -92,6 +99,7 @@ body {
 
 .title {
     font-size: 1rem;
+    font-family: "Playfair Display", serif;
     color: var(--accent-color);
     margin-bottom: 0.75rem;
     line-height: 1.4;
@@ -101,6 +109,7 @@ body {
     font-size: 0.875rem;
     color: var(--secondary-text);
     margin-bottom: 1rem;
+    font-family: "Space Mono", monospace;
 }
 
 .abstract {
@@ -108,7 +117,7 @@ body {
     line-height: 1.6;
     color: var(--text-color);
     margin-bottom: 1.5rem;
-    overflow-wrap: break-word;
+    overflow-y: scroll;
     word-wrap: break-word;
 }
 
@@ -241,6 +250,9 @@ body {
         width: 28px;
         height: 28px;
         font-size: 0.75rem;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .favorites-panel {
@@ -352,6 +364,7 @@ body {
     padding: 0.75rem;
     background: rgba(100, 255, 218, 0.05);
     border-radius: 8px;
+    font-family: "Space Mono", monospace;
     border-left: 3px solid var(--accent-color);
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1cfec33b-bdcf-4d63-9725-b39ba3c29dd2)


downside, if content is too small, there is space left below

![image](https://github.com/user-attachments/assets/ebae3cb6-a093-44a3-8e49-bde242e23aca)
